### PR TITLE
Avoid counting non-countable type

### DIFF
--- a/lib/form/sfFormField.class.php
+++ b/lib/form/sfFormField.class.php
@@ -320,6 +320,10 @@ class sfFormField
    */
   public function hasError()
   {
-    return null !== $this->error && count($this->error);
+    if ($this->error instanceof sfValidatorErrorSchema) {
+      return $this->error->count() > 0;
+    }
+    
+    return $this->error !== null;
   }
 }


### PR DESCRIPTION
BC break in PHP 7.2 - https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types